### PR TITLE
Drop libqdMetaData.system

### DIFF
--- a/msm8909/libqdutils/Android.bp
+++ b/msm8909/libqdutils/Android.bp
@@ -29,14 +29,3 @@ cc_library_shared {
     ],
     srcs: ["qdMetaData.cpp","qd_utils.cpp"],
 }
-
-// Remove after WFD moves to use libqdMetaData directly
-cc_library_shared {
-    name: "libqdMetaData.system",
-    defaults: ["display_defaults"],
-    cflags: [
-        "-Wno-sign-conversion",
-        "-DLOG_TAG=\"qdmetadata\"",
-    ],
-    srcs: ["qdMetaData.cpp","qd_utils.cpp"],
-}


### PR DESCRIPTION
Fixes on A14:
error: hardware/qcom-caf/msm8996/display/libqdutils/Android.bp:35:1: module "libqdMetaData.system" variant "android_arm64_armv8-2a-dotprod_cortex-a76_shared": clang: property is deprecated, see Changes.md file